### PR TITLE
remove `go install` - redundant with `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Run:
 
 ```sh
 go get github.com/yahoo/crypki
-go install github.com/yahoo/crypki/cmd/crypki
 ```
 
 ## Usage 


### PR DESCRIPTION
PR removes `go install` command in the README installation instruction as it is redundant with `go get` (which fetches and installs the given package).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
