### PR TITLE
add skip_cleanup for deploy travis step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ deploy:
   file:
     - crypki-amd64
     - crypki-amd64.sha256
+  skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
https://docs.travis-ci.com/user/deployment/releases/ says:
> Make sure you have skip_cleanup set to true, otherwise Travis CI will delete all the files created during the build, which will probably delete what you are trying to upload.

@maditya 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
